### PR TITLE
FIX: Attribute page visits to the session user, not client-supplied user_id

### DIFF
--- a/app/controllers/discourse_page_visits/page_visits_controller.rb
+++ b/app/controllers/discourse_page_visits/page_visits_controller.rb
@@ -6,7 +6,11 @@ module ::DiscoursePageVisits
 
     def create
       params_with_request =
-        page_visit_params.merge(ip_address: request.remote_ip, user_agent: request.user_agent)
+        page_visit_params.merge(
+          ip_address: request.remote_ip,
+          user_agent: request.user_agent,
+          user_id: current_user&.id,
+        )
       new_page_visit = PageVisit.new(params_with_request)
 
       if new_page_visit.save
@@ -19,7 +23,7 @@ module ::DiscoursePageVisits
     private
 
     def page_visit_params
-      params.permit(:visit_time, :full_url, :user_id, :topic_id, :ip_address, post_ids: [])
+      params.permit(:visit_time, :full_url, :topic_id, post_ids: [])
     end
   end
 end

--- a/spec/requests/page_visits_controller_spec.rb
+++ b/spec/requests/page_visits_controller_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscoursePageVisits::PageVisitsController do
+  fab!(:user)
+  fab!(:other_user, :user)
+  fab!(:topic)
+  fab!(:topic_post) { Fabricate(:post, topic: topic) }
+
+  let(:page_visit_params) do
+    {
+      full_url: "http://test.localhost/t/#{topic.slug}/#{topic.id}",
+      topic_id: topic.id,
+      post_ids: [topic_post.id],
+      visit_time: 1000,
+      user_id: other_user.id,
+    }
+  end
+
+  before { SiteSetting.discourse_page_visits_enabled = true }
+
+  describe "#create" do
+    it "stores the authenticated user as the visit user" do
+      sign_in(user)
+
+      expect {
+        post "/page-visits.json",
+             params: page_visit_params,
+             headers: {
+               "HTTP_USER_AGENT" => "RSpec",
+             }
+      }.to change { DiscoursePageVisits::PageVisit.count }.by(1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq("success" => "OK")
+      expect(DiscoursePageVisits::PageVisit.last).to have_attributes(
+        user_id: user.id,
+        full_url: page_visit_params[:full_url],
+        topic_id: topic.id,
+        post_ids: [topic_post.id],
+        visit_time: 1000,
+      )
+    end
+
+    it "stores no visit user for anonymous requests" do
+      expect {
+        post "/page-visits.json",
+             params: page_visit_params,
+             headers: {
+               "HTTP_USER_AGENT" => "RSpec",
+             }
+      }.to change { DiscoursePageVisits::PageVisit.count }.by(1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq("success" => "OK")
+      expect(DiscoursePageVisits::PageVisit.last.user_id).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
This plugin would trust blindly the provided`user_id` and used it to build the `PageVisit` record with no check against the current session.

Since the endpoint is public (no login required), any visitor, including anonymous ones, could POST an arbitrary `user_id` and attribute page-visit records to another user, or to a user that doesn't exist. This lets an attacker forge per-user analytics and mislead site owners about who viewed what.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>

Source: patch-triage/1253